### PR TITLE
Remove arrow functions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -56,7 +56,7 @@ class PersonalityTraitDescriptions {
   }
 
   descriptions() {
-    return pairs(this._descriptions).map(p => p[1]);
+    return pairs(this._descriptions).map(function(p) { return p[1]; });
   }
 }
 


### PR DESCRIPTION
Usage of arrow functions causes runtime issues with ionic + angular